### PR TITLE
I2C scan should write, not read.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .vscode
+.cache

--- a/lib/i2c_utils.cpp
+++ b/lib/i2c_utils.cpp
@@ -18,12 +18,13 @@ bool txoPresent             = false;
 // enumerate over all things on i2c bus. If they respond, set a flag
 void scanI2Cbus() {
   int ret;
-  uint8_t rxdata;
+  uint8_t txdata = 0x00;
 
   for (uint8_t addr = 8; addr < 120; addr++) {
-    ret = i2c_read_blocking(i2c1, addr, &rxdata, 1, false);
+    // ret = i2c_read_blocking(i2c1, addr, &rxdata, 1, false);
+    ret = i2c_write_blocking(i2c1, addr, &txdata, 1, false);
 
-    if (ret >= 0) {
+    if (ret != PICO_ERROR_GENERIC) {
       if (addr == ansibleI2Caddress) {
         ansiblePresent = true;
       }


### PR DESCRIPTION
Teensy code was scanning using write; not all devices respond to reads, (eg: Disting NX) and as such, this was failing.

Fortunately, the Pico SDK documentation suggests we can use response to writes - either a failure or result - as a way of detecting if devices exist on the bus.

This relates to issue #16.